### PR TITLE
Theme shop: Put creator in i18n string as field

### DIFF
--- a/en.json
+++ b/en.json
@@ -361,7 +361,7 @@
                     },
                     "active": "Currently active",
                     "use": "Use theme",
-                    "by": "by"
+                    "by": "by {{creator}}"
                 },
                 "feedback": {
                     "title": "Feedback",


### PR DESCRIPTION
Makes the `app.settings.pages.theme_shop.by` i18n string take the theme creator as a field, to allow translations to reorder elements.
Paired with https://github.com/revoltchat/revite/pull/517