### PR TITLE
Fix: Clarification when changing username (German)

### DIFF
--- a/de.json
+++ b/de.json
@@ -17,7 +17,7 @@
         "email": "E-Mail",
         "password": "Passwort",
         "enter": {
-            "username": "Gib deinen Nutzernamen an.",
+            "username": "Gib deinen bevorzugten Nutzernamen an.",
             "email": "Gib deine E-Mail-Adresse ein.",
             "password": "Gib ein Passwort an.",
             "current_password": "Gib dein aktuelles Passwort ein.",


### PR DESCRIPTION
I added the word "bevorzugten" to the string since asking someone to give you their username ("Gib deinen Nutzernamen an." ) would mean in German that you are supposed to give them your current username, and since you request a password too feels more like some kind of a captcha (for example GitHub when deleting something etc.) that you have to go trough to then change your username. I know this is not the case but I'm sure it will save many German users some confusion.
Adding the word "neuen" ("new") instead of "bevorzugten" would also work, but I figured the later is closer to the original English version wich uses the word "preferred".