### PR TITLE
Fix maintainer link README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The following table shows languages and people enlisted for verifying certain la
 |🪄|Enchantment Table / enchantment|||
 |🐖|Pig Latin / piglatin|||
 
-If you would like to maintain a language, please [open an issue](https://github.com/revoltchat/transations/issues/new/choose) with your request.
+If you would like to maintain a language, please [open an issue](https://github.com/revoltchat/translations/issues/new/choose) with your request.
 
 ### What do I do? 
 


### PR DESCRIPTION
Previous maintainer request link was broken, missing one character

## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
